### PR TITLE
netconf_client: support multiple sequential tests

### DIFF
--- a/netconf_client/netconf_client.js
+++ b/netconf_client/netconf_client.js
@@ -3,6 +3,7 @@
  *
  * Author: Petar Koretic <petar.koretic@sartura.hr>
  * Author: Luka Perkov <luka.perkov@sartura.hr>
+ * Author: Mak Krnic <mak.krnic@sartura.hr>
  *
  * testconf is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,8 +20,9 @@ var events = require("events")
 var util = require('util')
 var path = require('path')
 var Promise = require('promise')
+var vasync = require('vasync')
+var xml2js = require('xml2js')
 
-var xml2js = require('../core/xml2js-promise')
 var netconf = require('../core/netconf')
 var debug = require('../core/debug')
 var config = require('../core/config')
@@ -47,6 +49,7 @@ var client = function(options)
 	var messages_queue = []
 
 	var netconf_ready = false;
+	var connection_open = false;
 
 	events.EventEmitter.call(this);
 
@@ -77,6 +80,13 @@ var client = function(options)
 
 	var log_file = null
 
+	var methods_queue = []
+
+	var global_resolve = null
+	var global_reject  = null
+
+	this.netconf = null
+
 	ssh_opts.host = self.host
 	ssh_opts.port = self.port
 
@@ -90,131 +100,123 @@ var client = function(options)
 		ssh_opts.password = self.pass
 	}
 
-	var processRequest = function(resolve, reject)
+	var parseRequest = function(request, callback)
 	{
-		return function (request)
-		{
-			debug.write('<<<< msg netconf <<<<', false, self.log_file)
-			debug.write(request, false, self.log_file)
-			debug.write('---- msg netconf ----', false, self.log_file)
-
-			xml2js.parseString(request).then(function(data)
-			{
-				if (data["hello"])
-				{
-					if (netconf_ready)
-					{
-						debug.write('..... hello received at the wrong stage', true, self.log_file)
-						return reject('hello received at the wrong stage')
-					}
-
-					debug.write('..... hello', true, self.log_file)
-					netconf_ready = 1
-
-					var capabilities = data["hello"]["capabilities"][0].capability;
-
-					for (var i in capabilities)
-					{
-						debug.write('...... capability - ' + capabilities[i], true, self.log_file)
-
-						if (capabilities[i] == 'urn:ietf:params:netconf:base:1.1')
-						{
-							self.netconf_base = 1;
-						}
-					}
-
-					resolve(self)
-					return
-				}
-
-				if (data["rpc-reply"])
-				{
-					var msg_id = data["rpc-reply"].$["message-id"]
-					if (typeof messages_queue[msg_id] === 'undefined')
-					{
-						debug.write('..... rpc-reply with incorrect message id', true, self.log_file)
-						return reject("rpc-reply with incorrect message id")
-					}
-
-					debug.write('..... rpc-reply', true, self.log_file)
-
-					messages_queue[msg_id](request)
-					delete messages_queue[msg_id]
-				}
-			},
-			function(error)
-			{
-				debug.write('.... xml parsing failed', true, self.log_file)
-				debug.write(error, false, self.log_file)
-
-				return reject(error)
-			})
-		}
 	}
 
+	var errorHandler = function(error) {
+		ssh.end()
+		return global_reject && global_reject(error)
+	}
+
+	var sendHello = function() {
+		debug.write('.... sending client hello', true, self.log_file)
+		debug.write('>>>> msg netconf hello >>>>', false, self.log_file)
+		debug.write(netconf.hello(self.capabilities), false, self.log_file)
+		debug.write('---- msg netconf hello ----', false, self.log_file)
+
+		self.netconf.write(netconf.hello(self.capabilities));
+	}
 
 	var startSshClientSession = function(ssh_opts)
 	{
 		return new Promise(function(resolve, reject)
 		{
-			ssh.connect(ssh_opts);
 
-			ssh.on('ready', function()
-			{
+			ssh.on('ready', function() {
 				debug.write('.. ssh connection ready', true, self.log_file)
+				vasync.waterfall([
+					function(next) {
+						ssh.subsys('netconf', next)
+					},
+					function(stream, next) {
+						self.netconf = stream
+						debug.write('... netconf subsystem acquired', true, self.log_file)
+						sendHello()
 
-				ssh.subsys('netconf', function(error, stream)
-				{
-					if (error)
-					{
-						ssh.end()
-						return reject && reject(error)
+						stream.on('error', function(error)
+						{
+							debug.write('.. ssh stream close error', true, self.log_file)
+							connection_open = false
+							errorHandler(error)
+						})
+
+						stream.on('close', function()
+						{
+							debug.write('.. ssh stream close', true, self.log_file)
+							connection_open = false
+							ssh.end();
+						});
+
+						stream.on('data', function processHello(data)
+						{
+							connection_open = true
+							debug.write('.... received (partial) msg, len: ' + data.toString().length, false, self.log_file)
+							debug.write('<<<< partial msg <<<<', false, self.log_file)
+							debug.write(data.toString(), false, self.log_file)
+							debug.write('---- partial msg ----', false, self.log_file)
+
+							self.buffer += data.toString();
+
+							debug.write('.... processing incoming request', true, self.log_file)
+							netconf.process_message(self, function(request) {
+								debug.write('<<<< msg netconf <<<<', false, self.log_file)
+								debug.write(request, false, self.log_file)
+								debug.write('---- msg netconf ----', false, self.log_file)
+
+								xml2js.parseString(request, function(error, data)
+								{
+									if (error) {
+										debug.write('.... xml parsing failed', true, self.log_file)
+										debug.write(error, false, self.log_file)
+										callback("xml parsing failed")
+										return
+									}
+
+									if (data['hello']) {
+										if (netconf_ready)
+										{
+											debug.write('..... hello received at the wrong stage', true, self.log_file)
+											return next('hello received at the wrong stage')
+										}
+
+										debug.write('..... hello', true, self.log_file)
+										netconf_ready = 1
+
+										var capabilities = data["hello"]["capabilities"][0].capability;
+
+										for (var i in capabilities)
+										{
+											debug.write('...... capability - ' + capabilities[i], true, self.log_file)
+
+											if (capabilities[i] == 'urn:ietf:params:netconf:base:1.1')
+											{
+												self.netconf_base = 1;
+											}
+										}
+
+										stream.removeListener('data', processHello)
+										stream.on('data', self.processMessage)
+										next(null)
+										resolve()
+										return
+									}
+
+								})
+							})
+						})
 					}
-
-					con = stream
-
-					debug.write('... netconf subsystem acquired', true, self.log_file)
-
-					if (self.send_hello_message)
-					{
-						debug.write('.... sending client hello', true, self.log_file)
-						debug.write('>>>> msg netconf hello >>>>', false, self.log_file)
-						debug.write(netconf.hello(self.capabilities), false, self.log_file)
-						debug.write('---- msg netconf hello ----', false, self.log_file)
-
-						stream.write(netconf.hello(self.capabilities));
+				],
+				function err(error) {
+					if (error) {
+						console.log("error")
+						console.log(error)
 					}
-
-					stream.on('error', function(error)
-					{
-						debug.write('.. ssh stream close', true, self.log_file)
-						ssh.end()
-						return reject && reject(error)
-					})
-
-					stream.on('close', function()
-					{
-						debug.write('.. ssh stream close', true, self.log_file)
-						ssh.end();
-					});
-
-					stream.on('data', function(data, extended)
-					{
-						debug.write('.... received (partial) msg, len: ' + data.toString().length, false, self.log_file)
-						debug.write('<<<< partial msg <<<<', false, self.log_file)
-						debug.write(data.toString(), false, self.log_file)
-						debug.write('---- partial msg ----', false, self.log_file)
-
-						self.buffer += data.toString();
-
-						debug.write('.... processing incoming request', true, self.log_file)
-						netconf.process_message(self, processRequest(resolve, reject))
-					})
 				})
 			})
-
-			ssh.on('error', function(error)
+			.on('error', function(error)
 			{
+				connection_open = false
 				if (!netconf_ready)
 				{
 					return reject && reject(error)
@@ -222,110 +224,154 @@ var client = function(options)
 
 				debug.write('.. ssh connection closed due to error', true, self.log_file)
 				debug.write(error, false, self.log_file)
-				fs.closeSync(self.log_file);
-				return reject && reject(error)
+				//fs.closeSync(self.log_file);
+				//throw 'error 1'
 			})
-
-			ssh.on('close', function(had_error)
+			.on('close', function(had_error)
 			{
+				connection_open = false
 				debug.write('.. ssh connection closed', true, self.log_file)
-				fs.closeSync(self.log_file);
+				//fs.closeSync(self.log_file);
 			});
+
+			ssh.connect(ssh_opts);
 		})
 	}
 
-	this.send = function(message)
+	this.processMessage = function (data) {
+		debug.write('.... received (partial) msg, len: ' + data.toString().length, false, self.log_file)
+		debug.write('<<<< partial msg <<<<', false, self.log_file)
+		debug.write(data.toString(), false, self.log_file)
+		debug.write('---- partial msg ----', false, self.log_file)
+
+		self.buffer += data.toString();
+
+		debug.write('.... processing incoming request', true, self.log_file)
+		netconf.process_message(self, function(request) {
+			debug.write('<<<< msg netconf <<<<', false, self.log_file)
+			debug.write(request, false, self.log_file)
+			debug.write('---- msg netconf ----', false, self.log_file)
+
+			xml2js.parseString(request, function(error, data) {
+				if (data["rpc-reply"])
+				{
+					var msg_id = data["rpc-reply"].$["message-id"]
+					if (typeof messages_queue[msg_id] === 'undefined')
+					{
+						debug.write('..... rpc-reply with incorrect message id', true, self.log_file)
+						return reject && reject("rpc-reply with incorrect message id")
+					}
+
+					debug.write('..... rpc-reply', true, self.log_file)
+
+					messages_queue[msg_id](request)
+					delete messages_queue[msg_id]
+					self.runOne()
+				}
+			})
+		})
+	}
+
+	this.send = function(message, callback)
 	{
-		var promise = new Promise(function(resolve, reject)
-		{
-			if (!con)
-			{
-				debug.write('... ssh stream has not been established', true, self.log_file)
-				reject && reject('ssh stream has not been established')
-			}
-
-			if (!netconf_ready)
-			{
-				debug.write('... netconf not ready, hello message has not been exchanged', true, self.log_file)
-				reject && reject('netconf not ready, hello message has not been exchanged')
-			}
-
+		var send_message = function() {
 			// create netconf message
 			var xml_message = netconf.create_rpc_message(message, self.netconf_base, message_id)
 
 			// add message to global queue
-			messages_queue[message_id++] = resolve
+			messages_queue[message_id++] = callback
 
 			// send message via ssh
-			con.write(xml_message);
+			self.netconf.write(xml_message);
 
 			debug.write('>>>> msg netconf >>>>', false, self.log_file)
 			debug.write(xml_message, false, self.log_file)
 			debug.write('---- msg netconf ----', false, self.log_file)
-		})
-
-		promise.thenDefault = function(resolve, reject)
-		{
-			if (typeof resolve === 'undefined')
-			{
-				resolve = function(success)
-				{
-					process.exit(0)
-				}
-			}
-
-			if (typeof reject === 'undefined')
-			{
-				reject = function(error)
-				{
-					console.error(error)
-					process.exit(1)
-				}
-			}
-
-			return promise.then(resolve, reject)
 		}
 
-		return promise
+		if (!connection_open)
+		{
+			debug.write('... ssh stream has not been established', true, self.log_file)
+			startSshClientSession(ssh_opts).then(function() {
+				if (!netconf_ready)
+				{
+					debug.write('... netconf not ready, hello message has not been exchanged', true, self.log_file)
+					errorHandler('netconf not ready, hello message has not been exchanged')
+				}
+				else {
+					send_message()
+				}
+			})
+		}
+		else {
+			send_message()
+		}
 	}
 
 	// standard netconf rpcs
-	this.send_get = function(filter)
+	this.get = function(filter, callback)
 	{
-		debug.write('.... sending msg (get)', true, self.log_file)
-		return self.send(netconf.get(filter))
+		debug.write('.... scheduling msg (get)', true, self.log_file)
+		methods_queue.push({method: self.send, args: netconf.get(filter), callback: callback})
+		return self
 	}
 
-	this.send_get_config = function(filter)
+	this.get_config = function(filter, callback)
 	{
-		debug.write('.... sending msg (get-config)', true, self.log_file)
-		return self.send(netconf.get_config(filter))
+		debug.write('.... scheduling msg (get-config)', true, self.log_file)
+		methods_queue.push({method: self.send, args: netconf.get_config(filter), callback: callback})
+		return self
 	}
 
-	this.send_close = function()
+	this.kill = function(session_id, callback)
 	{
-		debug.write('.... sending msg (close-session)', true, self.log_file)
-		//setBreakpoint().sb()
-		return self.send(netconf.close())
+		debug.write('.... scheduling msg (kill-session)', true, self.log_file)
+		methods_queue.push({method: self.send, args: netconf.kill(session_id), callback: callback})
+		return self
 	}
 
-	this.send_kill = function(session_id)
-	{
-		debug.write('.... sending msg (kill-session)', true, self.log_file)
-		return self.send(netconf.kill(session_id))
-	}
-
-	this.send_get_schema = function(schema)
+	this.get_schema = function(schema, callback)
 	{
 		if (!schema || !("identifier" in schema)) {
-			return new Promise.reject('missing mandatory argument "identifier" in schema')
+			throw new Error('missing mandatory argument "identifier" in schema')
 		}
 
-		debug.write('.... sending msg (get-schema)', true, self.log_file)
-		return self.send(netconf.get_schema(schema))
+		debug.write('.... scheduling msg (get-schema)', true, self.log_file)
+		methods_queue.push({method: self.send, args: netconf.get_schema(schema), callback: callback})
+		return self
 	}
 
-	return startSshClientSession(ssh_opts)
+	this.close = function(callback) {
+		debug.write('.... scheduling msg (close-session)', true, self.log_file)
+		methods_queue.push({method: self.send, args: netconf.close(), callback: callback})
+		return self
+	}
+
+	var run_resolve = null
+	var run_reject = null
+
+	this.runOne = function() {
+		if (methods_queue.length) {
+			global_resolve = self.runOne
+			var method = methods_queue.shift()
+			method.method(method.args, method.callback)
+		}
+		else {
+			run_resolve && run_resolve()
+		}
+	}
+
+	var index = 0;
+	this.run = function() {
+		return new Promise(function(resolve, reject) {
+			global_resolve = run_resolve = resolve
+			global_reject = run_reject = reject
+
+			self.runOne()
+		})
+	}
+
+	return this
 }
 
 util.inherits(client, events.EventEmitter);

--- a/netconf_client/tests/generic_hello.js
+++ b/netconf_client/tests/generic_hello.js
@@ -15,7 +15,31 @@
 
 var netconf_client = require('../netconf_client')
 
-netconf_client.create().then(function(client)
-{
-	client.send_close().thenDefault()
-})
+// netconf_client.create().then(function(client)
+// {
+// 	client.send_close().then()
+// })
+// .catch(function(ex) {
+// 	console.log('exc:')
+// 	console.log(ex)
+// })
+
+netconf_client.create()
+	.close(function() {
+		console.log('ac1')
+	})
+	.run()
+	.then(function(s) {
+		console.log("Success")
+		//console.log(s)
+	}, function(e) {
+		console.log("error")
+		console.log(e)
+	})
+	.catch(function(ex) {
+		console.log('exception')
+		console.log(ex)
+	})
+	.finally(function() {
+		process.exit(0)
+	})

--- a/netconf_client/tests/generic_rpc_get.js
+++ b/netconf_client/tests/generic_rpc_get.js
@@ -16,12 +16,49 @@
 var netconf_client = require('../netconf_client')
 var util = require('util');
 
-netconf_client.create().then(function(client)
-{
-	client.send_get().thenDefault(function(reply)
-	{
+//netconf_client.create().then(function(client)
+//{
+//	client.send_get().thenDefault(function(reply)
+//	{
+//		console.log(reply)
+//		console.log(util.inspect(reply, {showHidden: false, depth: null}));
+//		client.send_close().thenDefault()
+//	})
+//})
+
+netconf_client.create()
+	.get(null, function(reply) {
+		console.log("Reply")
 		console.log(reply)
 		console.log(util.inspect(reply, {showHidden: false, depth: null}));
-		client.send_close().thenDefault()
 	})
-})
+	.get(null, function(reply) {
+		console.log("Reply")
+		console.log(reply)
+		console.log(util.inspect(reply, {showHidden: false, depth: null}));
+	})
+	.get(null, function(reply) {
+		console.log("Reply")
+		console.log(reply)
+		console.log(util.inspect(reply, {showHidden: false, depth: null}));
+	})
+	.get(null, function(reply) {
+		console.log("Reply")
+		console.log(reply)
+		console.log(util.inspect(reply, {showHidden: false, depth: null}));
+	})
+	.run()
+	.then(function(s) {
+		console.log("Success")
+		//console.log(s)
+	}, function(e) {
+		console.log("error")
+		console.log(e)
+	})
+	.catch(function(ex) {
+		console.log('exception')
+		console.log(ex)
+	})
+	.finally(function() {
+		process.exit(0)
+	})

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
 		"promise": "7.1.1",
 		"libyang": "1.0.9",
 		"libxmljs": "0.18.0",
-		"pretty-data": "0.40.0"
+		"pretty-data": "0.40.0",
+		"vasync": "1.6.4"
 	},
 	"engine": "node >= 0.10.31",
 	"contributors": [


### PR DESCRIPTION
add support for chaining multiple tests in form of builder-like pattern

``` js
netconf_client.create()                                                
  .get(null, function(reply) {                                         
    console.log("Reply")                                               
    console.log(reply)                                                 
    console.log(util.inspect(reply, {showHidden: false, depth: null}));
  })                                                                   
  .get(null, function(reply) {                                         
    console.log("Reply")                                               
    console.log(reply)                                                 
    console.log(util.inspect(reply, {showHidden: false, depth: null}));
  })                                                                   
```
